### PR TITLE
set client id in localStorage

### DIFF
--- a/src/frontend/user-uses.tsx
+++ b/src/frontend/user-uses.tsx
@@ -64,6 +64,15 @@ function UserItems({userID, items}: any){
       return bDate.getTime() - aDate.getTime()
     })
   }
+
+  if (filteredItems.length === 0) {
+    return (
+      <div className={'pt-2 pl-8'}>
+        No items yet
+      </div>
+    )
+  }
+
   return (
     <div className={'pt-2'}>
       {filteredItems.map((item: any) => {

--- a/src/pages/uses/[username].tsx
+++ b/src/pages/uses/[username].tsx
@@ -11,6 +11,9 @@ import UserUses from '../../frontend/user-uses';
 export default function Home() {
   const [reflect, setReflectClient] = useState<Reflect<M> | null>(null);
   const [_, setOnline] = useState(false);
+  const [clientUserID, setClientUserID] = useState<string | null>(null);
+
+  const LOCAL_STORAGE_KEY = 'uses.userID'
 
   const logSink = process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN
     ? new DataDogBrowserLogSink()
@@ -22,7 +25,7 @@ export default function Home() {
 
     (async () => {
       logger.info?.(`Connecting to worker at ${workerWsURI}`);
-      const userID = nanoid();
+      const userID = clientUserID ? clientUserID : nanoid();
       const r = new Reflect<M>({
         socketOrigin: workerWsURI,
         onOnlineChange: setOnline,
@@ -46,6 +49,12 @@ export default function Home() {
       setReflectClient(r);
     })();
   }, []);
+
+  useEffect(() => {
+    const userID = localStorage.getItem(LOCAL_STORAGE_KEY)
+    if ( userID != null) setClientUserID(userID)
+  },[])
+
 
   if (!reflect) {
     return null;

--- a/src/pages/uses/index.tsx
+++ b/src/pages/uses/index.tsx
@@ -12,6 +12,10 @@ export default function Home() {
   const [reflect, setReflectClient] = useState<Reflect<M> | null>(null);
   const [_, setOnline] = useState(false);
 
+  const [clientUserID, setClientUserID] = useState<string | null>(null);
+
+  const LOCAL_STORAGE_KEY = 'uses.userID'
+
   const logSink = process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN
     ? new DataDogBrowserLogSink()
     : consoleLogSink;
@@ -22,7 +26,7 @@ export default function Home() {
 
     (async () => {
       logger.info?.(`Connecting to worker at ${workerWsURI}`);
-      const userID = nanoid();
+      const userID = clientUserID ? clientUserID : nanoid();
       const r = new Reflect<M>({
         socketOrigin: workerWsURI,
         onOnlineChange: setOnline,
@@ -46,6 +50,12 @@ export default function Home() {
       setReflectClient(r);
     })();
   }, []);
+
+  useEffect(() => {
+    const userID = localStorage.getItem(LOCAL_STORAGE_KEY)
+    if ( userID != null) setClientUserID(userID)
+  },[])
+
 
   if (!reflect) {
     return null;


### PR DESCRIPTION
- show `no items yet` for user page with no items
- set and store `nanoid()` for client in localStorage (prevent replicache/reflect from pulling new data into indexedDB on every refresh)


